### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ torque@bittorrent.com
 patrick@bittorrent.com  
 [@pwmckenna](http://twitter.com/pwmckenna)  
 
-##License
+## License
 Copyright 2012 Patrick Williams, BitTorrent Inc.
 http://torque.bittorrent.com/
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
